### PR TITLE
feat(schedule): add MPV Medianeira dates for 2026

### DIFF
--- a/src/data/schedule2026.js
+++ b/src/data/schedule2026.js
@@ -28,12 +28,24 @@ const schedule = [
     description: "MPV - SRP Londrina-PR",
   },
   {
+    date: { day: "01", month: "AGOSTO", fulldate: "2026-08-01" },
+    description: "MPV - Medianeira-PR",
+  },
+  {
     date: { day: "15", month: "AGOSTO", fulldate: "2026-08-15" },
     description: "MPV - SRM Maringá-PR",
   },
   {
+    date: { day: "05", month: "SETEMBRO", fulldate: "2026-09-05" },
+    description: "MPV - Medianeira-PR",
+  },
+  {
     date: { day: "12", month: "SETEMBRO", fulldate: "2026-09-12" },
     description: "MPV - SRP Londrina-PR",
+  },
+  {
+    date: { day: "17", month: "OUTUBRO", fulldate: "2026-10-17" },
+    description: "MPV - Medianeira-PR",
   },
   {
     date: { day: "31", month: "OUTUBRO", fulldate: "2026-10-31" },


### PR DESCRIPTION
## Summary
- Add three new entries for `MPV - Medianeira-PR` in the 2026 schedule
- Include dates for 01/08, 05/09, and 17/10 in chronological order

## Test plan
- [x] Run `node --check src/data/schedule2026.js`

Made with [Cursor](https://cursor.com)